### PR TITLE
Add styling helper gems recipe

### DIFF
--- a/recipes/bitters.rb
+++ b/recipes/bitters.rb
@@ -1,0 +1,17 @@
+gem 'bitters'
+
+stage_two do
+  run 'cd app/assets/stylesheets/ && bundle exec bitters install'
+  insert_into_file 'app/assets/stylesheets/application.scss',
+                   "@import \"base/base\";\n",
+                   after: "@import \"bourbon\";\n"
+end
+
+__END__
+
+name: bitters
+description: "Add bitters to your application"
+
+category: frontend
+requires: [bourbon]
+run_after: [bourbon]

--- a/recipes/bourbon.rb
+++ b/recipes/bourbon.rb
@@ -1,0 +1,14 @@
+gem 'bourbon'
+
+stage_two do
+  prepend_to_file 'app/assets/stylesheets/application.scss',
+                  "@import \"bourbon\";\n"
+end
+__END__
+
+name: bourbon
+description: "Add bourbon to your application"
+
+category: frontend
+requires: [sass_setup]
+run_after: [sass_setup]

--- a/recipes/neat.rb
+++ b/recipes/neat.rb
@@ -1,0 +1,8 @@
+gem 'neat'
+
+__END__
+
+name: neat
+description: "Add neat to your application"
+
+category: frontend

--- a/recipes/sass_setup.rb
+++ b/recipes/sass_setup.rb
@@ -1,0 +1,9 @@
+remove_file 'app/assets/stylesheets/application.css'
+create_file 'app/assets/stylesheets/application.scss'
+
+__END__
+
+name: sass_setup
+description: "Use SASS"
+
+category: frontend


### PR DESCRIPTION
Why?

> We want the gems for:
> - bourbon
> - bitters
> - neat
> 
> to have a recipe.
> closes https://github.com/spartansystems/spartan-composer-recipes/issues/3

How?
- add recipe that changes `app/assets/sytlesheets.css` to `.scss`
- add recipe for bourbon that includes the gem and imports bourbon
  into the scss file
- add recipe for bitters that includes the gem, runs the generator,
  and imports it into the scss file
- add recipe for neat that includes the gem
