### PR TITLE
Add performance evaluation recipes

### DIFF
--- a/files/config/initializers/bullet.rb
+++ b/files/config/initializers/bullet.rb
@@ -1,0 +1,12 @@
+if %w(development staging).include?(ENV["APPLICATION_ENVIRONMENT"])
+  Rails.application.configure do
+    config.after_initialize do
+      Bullet.enable = true
+      Bullet.console = true
+      Bullet.rails_logger = true
+      Bullet.rollbar = true
+      Bullet.alert = !ENV["BULLET_SHOW_ALERT"].nil?
+      Bullet.add_footer = !ENV["BULLET_SHOW_FOOTER"].nil?
+    end
+  end
+end

--- a/recipes/bullet.rb
+++ b/recipes/bullet.rb
@@ -1,0 +1,17 @@
+gem "bullet", group: :development
+
+after_bundle do
+  copy_from_repo "config/initializers/bullet.rb", repo: REPO
+
+  append_to_file ".env.example" do
+    "BULLET_SHOW_ALERT=true\nBULLET_SHOW_FOOTER=true\n"
+  end
+end
+__END__
+
+name: bullet
+description: "Add bullet to your application"
+
+category: other
+requires: [dotenv]
+run_after: [dotenv]

--- a/recipes/derailed.rb
+++ b/recipes/derailed.rb
@@ -1,0 +1,8 @@
+gem "derailed", group: :development
+
+__END__
+
+name: derailed
+description: "Add derailed to your application"
+
+category: other

--- a/recipes/dotenv.rb
+++ b/recipes/dotenv.rb
@@ -1,0 +1,12 @@
+REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
+gem "dotenv-rails", group: [:development, :test]
+
+after_bundle do
+  copy_from_repo ".env.example", repo: REPO
+end
+
+__END__
+name: dotenv
+description: "Add rollbar to your application"
+
+category: configuration

--- a/recipes/performance_evaluation.rb
+++ b/recipes/performance_evaluation.rb
@@ -1,0 +1,8 @@
+__END__
+
+name: performance_evaluation
+description: "Add Spartan's recommended performance evaluation gems to
+  your application"
+
+category: other
+requires: [bullet, derailed, rack_mini_profiler, rollbar, stackprof]

--- a/recipes/rack_mini_profiler.rb
+++ b/recipes/rack_mini_profiler.rb
@@ -1,0 +1,8 @@
+gem "rack-mini-profiler", group: :development
+
+__END__
+
+name: rack-mini-profiler
+description: "Add rack-mini-profiler to your application"
+
+category: other

--- a/recipes/rollbar.rb
+++ b/recipes/rollbar.rb
@@ -1,0 +1,19 @@
+REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
+gem "rollbar"
+
+after_bundle do
+  copy_from_repo "config/initializers/rollbar.rb", repo: REPO
+  copy_from_repo "vendor/assets/javascripts/rollbar.js.erb", repo: REPO
+
+  append_to_file ".env.example" do
+    "ROLLBAR_CLIENT_ACCESS_TOKEN=''\nROLLBAR_SERVER_ACCESS_TOKEN=''\n"
+  end
+end
+__END__
+
+name: rollbar
+description: "Add rollbar to your application"
+
+category: other
+requires: [dotenv]
+run_after: [dotenv]

--- a/recipes/stackprof.rb
+++ b/recipes/stackprof.rb
@@ -1,0 +1,8 @@
+gem "stackprof", group: [:development, :test]
+
+__END__
+
+name: stackprof
+description: "Add stackprof to your application"
+
+category: other


### PR DESCRIPTION
Why?

> We want to have a recipe that includes:
> - [Rollbar](https://github.com/rollbar/rollbar-gem) - along with [rollbar.js](https://rollbar.com/docs/notifier/rollbar.js/#quick-start)
> - [Bullet](https://github.com/flyerhzm/bullet)
> - [Rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler)
> - [Derailed](https://github.com/schneems/derailed)
> - [Stackprof](https://github.com/tmm1/stackprof)

closes https://github.com/spartansystems/spartan-composer-recipes/issues/4

How?
- adds recipes for rollbar, bullet, rack-mini-profiler, derailed,
  and stackprof
- adds recipe called `performance_evaluation` that will install
  all those recipes
