### PR TITLE
Add gems that assist in development

### DIFF
--- a/recipes/pry.rb
+++ b/recipes/pry.rb
@@ -1,0 +1,12 @@
+gem_group :development, :test do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-rails"
+  gem "pry-remote"
+end
+
+__END__
+name: pry
+description: "Add pry and related gems to your application"
+
+category: development

--- a/recipes/spring_commands_rspec.rb
+++ b/recipes/spring_commands_rspec.rb
@@ -1,0 +1,10 @@
+gem "spring-commands-rspec", group: :development
+
+__END__
+
+name: spring-commands-rspec
+description: "Add spring-commands-rspec to your application"
+
+category: testing
+requires: [bourbon]
+run_after: [bourbon]


### PR DESCRIPTION
Why?

> We need a recipe to install the following dev tools:
> - spring
> - spring commands rspec
> - pry-byebug
> - pry-remote

closes https://github.com/spartansystems/spartan-composer-recipes/issues/5

How?
- add recipes that add gems for pry, pry-byebug, pry-remote, and
  spring-commands-rspec
