### PR TITLE
Add interactor recipe

### DIFF
--- a/recipes/interactor.rb
+++ b/recipes/interactor.rb
@@ -1,0 +1,8 @@
+gem "interactor-rails", "~> 2.0"
+
+__END__
+
+name: interactor
+description: "Add interactor-rails to your application"
+
+category: other


### PR DESCRIPTION
Why?

> A recipe to install interactor-rails

closes https://github.com/spartansystems/spartan-composer-recipes/issues/6

How?
- add a recipe for interactor-rails
