### PR TITLE
Add production gems

### DIFF
--- a/files/.env.example
+++ b/files/.env.example
@@ -1,4 +1,4 @@
 APPLICATION_ENVIRONMENT=development
-APPLICATION_HOST=
+APPLICATION_HOST=localhost:3000
 RACK_ENV=development
 RAILS_ENV=development

--- a/recipes/production_gems.rb
+++ b/recipes/production_gems.rb
@@ -1,0 +1,14 @@
+gem_group :production do
+  gem "lograge"
+  gem "newrelic_rpm"
+  gem "rack-timeout"
+  gem "rails_12factor"
+end
+
+__END__
+
+name: production_gems
+description: "Add Spartan's recommended production gems"
+
+category: other
+requires: [rack_canonical_host]

--- a/recipes/rack_canonical_host.rb
+++ b/recipes/rack_canonical_host.rb
@@ -1,0 +1,19 @@
+gem "rack-canonical-host"
+
+middleware_setup = <<-TEXT
+
+  config.middleware.insert_after 0, Rack::CanonicalHost, ENV['APPLICATION_HOST'] if ENV.key?('APPLICATION_HOST')
+TEXT
+
+inject_into_file(
+  "config/application.rb",
+  middleware_setup,
+  after: "class Application < Rails::Application"
+)
+
+__END__
+
+name: rack-canonical-host
+description: "Add rack-canonical-host to your application"
+
+category: other

--- a/recipes/rack_canonical_host.rb
+++ b/recipes/rack_canonical_host.rb
@@ -2,7 +2,8 @@ gem "rack-canonical-host"
 
 middleware_setup = <<-TEXT
 
-  config.middleware.insert_after 0, Rack::CanonicalHost, ENV['APPLICATION_HOST'] if ENV.key?('APPLICATION_HOST')
+  config.application_host = ENV.fetch('APPLICATION_HOST')
+  config.middleware.insert_after 0, Rack::CanonicalHost, config.application_host if Rails.env.production?
 TEXT
 
 inject_into_file(
@@ -10,6 +11,30 @@ inject_into_file(
   middleware_setup,
   after: "class Application < Rails::Application"
 )
+
+uncomment_lines(
+  "config/environments/production.rb",
+  "config.force_ssl = true"
+)
+
+inject_into_file(
+  "config/environments/production.rb",
+  "\n config.ssl_options = { host: config.application_host }",
+  after: "config.force_ssl = true"
+)
+
+mailer_host = <<-TEXT
+
+  config.action_mailer.default_url_options = { host: config.application_host }
+TEXT
+
+%w(production development).each do |env|
+  inject_into_file(
+    "config/environments/#{env}.rb",
+    mailer_host,
+    after: "config.action_mailer.raise_delivery_errors = false"
+  )
+end
 
 __END__
 


### PR DESCRIPTION
Why:
- We need 'em for running on heroku
- fixes #9 

This change addresses the need by:
- Adding gems in production group
- Separate recipe for rack-canonical host
- Add middlewhere to `application.rb`
