### PR TITLE
Add CORS config initializer

### DIFF
--- a/files/config/initializers/cors.rb
+++ b/files/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+Rails.application.configure do
+  config.middleware.use Rack::Cors do
+    allow do
+      origins ENV.fetch('CORS_ORIGINS', 'localhost').split(',').map(&:strip)
+      resource '*',
+               headers: :any,
+               expose: %w(access-token expiry token-type uid client),
+               methods: %i(get post options delete put)
+    end
+  end
+end

--- a/recipes/cors.rb
+++ b/recipes/cors.rb
@@ -1,18 +1,23 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
-gem "bullet", group: :development
+gem 'rack-cors'
 
 after_bundle do
   copy_from_repo "config/initializers/bullet.rb", repo: REPO
 
   append_to_file ".env.example" do
-    "BULLET_SHOW_ALERT=true\nBULLET_SHOW_FOOTER=true\n"
+    "CORS_ORIGINS=localhost\n"
+  end
+
+  append_to_file ".env" do
+    "CORS_ORIGINS=localhost\n"
   end
 end
+
 __END__
 
-name: bullet
-description: "Add bullet to your application"
+name: 'cors'
+description: 'Configure Rack CORS gem so Devise Auth Token works'
 
-category: other
+category: api
 requires: [dotenv]
 run_after: [dotenv]

--- a/recipes/dotenv.rb
+++ b/recipes/dotenv.rb
@@ -3,6 +3,7 @@ gem "dotenv-rails", group: [:development, :test]
 
 after_bundle do
   copy_from_repo ".env.example", repo: REPO
+  get "#{REPO}/.env.example", ".env"
 end
 
 __END__

--- a/recipes/rack_canonical_host.rb
+++ b/recipes/rack_canonical_host.rb
@@ -2,8 +2,8 @@ gem "rack-canonical-host"
 
 middleware_setup = <<-TEXT
 
-  config.application_host = ENV.fetch('APPLICATION_HOST')
-  config.middleware.insert_after 0, Rack::CanonicalHost, config.application_host if Rails.env.production?
+    config.application_host = ENV.fetch('APPLICATION_HOST')
+    config.middleware.insert_after 0, Rack::CanonicalHost, config.application_host if Rails.env.production?
 TEXT
 
 inject_into_file(
@@ -42,3 +42,5 @@ name: rack-canonical-host
 description: "Add rack-canonical-host to your application"
 
 category: other
+requires: [dotenv]
+run_after: [dotenv]


### PR DESCRIPTION
Why:

* We will need one for APIs that have a front end
* We need it to work well with other recipes

This change addresses the need by:

* Update some recipes to work well in concert with other ENV modifying recipes
* Add a `cors.rb` initializer file
* Add a cors recipe for installing the gem/initializer/env vars