### PR TITLE
Add devise token auth recipe

### DIFF
--- a/recipes/bullet.rb
+++ b/recipes/bullet.rb
@@ -1,7 +1,7 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
 gem "bullet", group: :development
 
-after_bundle do
+stage_two do
   copy_from_repo "config/initializers/bullet.rb", repo: REPO
 
   append_to_file ".env.example" do

--- a/recipes/cors.rb
+++ b/recipes/cors.rb
@@ -1,8 +1,8 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
 gem 'rack-cors'
 
-after_bundle do
-  copy_from_repo "config/initializers/bullet.rb", repo: REPO
+stage_two do
+  copy_from_repo "config/initializers/cors.rb", repo: REPO
 
   append_to_file ".env.example" do
     "CORS_ORIGINS=localhost\n"

--- a/recipes/devise_token_auth.rb
+++ b/recipes/devise_token_auth.rb
@@ -1,0 +1,22 @@
+gem 'devise_token_auth'
+
+stage_three do
+  run 'bin/rails g devise_token_auth:install User api/auth'
+  inject_into_file(
+    "config/routes.rb",
+    ", skip: [:omniauth_callbacks]",
+    after: "at: 'api/auth'"
+  )
+  gsub_file(
+    "app/models/user.rb",
+    ', :omniauthable',
+    '')
+  run 'bin/rails db:migrate'
+end
+
+__END__
+
+name: 'Devise Token Auth'
+description: 'For API authentication backed by Devise'
+
+category: api

--- a/recipes/dotenv.rb
+++ b/recipes/dotenv.rb
@@ -1,7 +1,7 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
 gem "dotenv-rails", group: [:development, :test]
 
-after_bundle do
+stage_two do
   copy_from_repo ".env.example", repo: REPO
   get "#{REPO}/.env.example", ".env"
 end

--- a/recipes/rollbar.rb
+++ b/recipes/rollbar.rb
@@ -1,7 +1,7 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
 gem "rollbar"
 
-after_bundle do
+stage_two do
   copy_from_repo "config/initializers/rollbar.rb", repo: REPO
   copy_from_repo "vendor/assets/javascripts/rollbar.js.erb", repo: REPO
 

--- a/recipes/slim_lint.rb
+++ b/recipes/slim_lint.rb
@@ -1,7 +1,7 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
 gem "slim_lint"
 
-after_bundle do
+stage_two do
   copy_from_repo ".slim-lint.yml", repo: REPO
 end
 


### PR DESCRIPTION
Why:

* So we can bootstrap a rails app with an API auth solution
* So all recipes play nice together

This change addresses the need by:

* Make all recipes use stages over `after_...`
* Add recipe for devise_token_auth