### PR TITLE
Make require conditional

### DIFF
--- a/files/config/initializers/rollbar.rb
+++ b/files/config/initializers/rollbar.rb
@@ -1,5 +1,5 @@
 require "rollbar/rails"
-require "rack/timeout/rollbar"
+require "rack/timeout/rollbar" if Rails.env.production?
 Rollbar.configure do |config|
   if ENV["ROLLBAR_SERVER_ACCESS_TOKEN"]
     config.js_enabled = false


### PR DESCRIPTION
Why:

* Because rack-timeout is only available in prod

This change addresses the need by:

* Only requiring if in the production environment