### PR TITLE
Fix bullet to run in test ENV

### DIFF
--- a/recipes/bullet.rb
+++ b/recipes/bullet.rb
@@ -1,5 +1,5 @@
 REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
-gem "bullet", group: :development
+gem "bullet"
 
 stage_two do
   copy_from_repo "config/initializers/bullet.rb", repo: REPO


### PR DESCRIPTION
Why:

* It was only installed for DEV which would fail during specs

This change addresses the need by:

* Remove group constraint from bundler