### PR TITLE
Add DB config

### DIFF
--- a/files/config/database.yml
+++ b/files/config/database.yml
@@ -1,0 +1,26 @@
+pg_default: &pg_default
+  adapter: postgresql
+  encoding: unicode
+  host: localhost
+  pool: <%= ENV["DB_POOL"] || ENV["MAX_THREADS"] || 20 %>
+  username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "") %>
+  reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
+  timeout: 5000
+
+default: &default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
+
+test:
+  <<: *default
+  database: db/test.sqlite3
+  min_messages: warning
+
+production: &deploy
+  url: <%= ENV["DATABASE_URL"] %>

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -1,0 +1,12 @@
+REPO = "https://raw.githubusercontent.com/spartansystems/spartan-composer-recipes/master/files/".freeze
+gem "pg"
+
+stage_one do
+  copy_from_repo "config/database.yml", repo: REPO
+end
+__END__
+
+name: database
+description: "Add custom Spartan Database configuration"
+
+category: configuration


### PR DESCRIPTION
Why:

* So we can have a simple default (sqlite)
* We can make it as easy as possible to get to recommended default (postgres)

This change addresses the need by:

* Adding a custom db config file
* Adding a recipe for installing the config